### PR TITLE
feat: add blog read command, fix comment docs, bump to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [0.1.3] - 2025-04-25
+
+### Added
+
+- `blog read <id>` command to read blog post body content with `--format` support (storage, html, text, markdown)
+
+### Fixed
+
+- `read --format markdown` now converts HTML to markdown instead of outputting raw HTML
+- Comments list now expands `history` so author and date are populated
+- Comments list uses correct `extensions` (plural) API field for location, resolution, and inline metadata
+- Default comment location changed from "unknown" to "footer" when API doesn't return a location
+- Removed non-existent `comment <pageId>` alias from README; examples updated to use `comment add <pageId>`
+
 ## [0.1.2] - 2025-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -441,17 +441,17 @@ confluence comments 123456789
 confluence comments 123456789 --location inline --format markdown
 
 # Create a footer comment
-confluence comment 123456789 --content "Looks good to me!"
+confluence comment add 123456789 --content "Looks good to me!"
 
 # Create an inline comment
-confluence comment 123456789 \
+confluence comment add 123456789 \
   --location inline \
   --content "Consider renaming this" \
   --inline-selection "foo" \
   --inline-original-selection "foo"
 
 # Reply to a comment
-confluence comment 123456789 --parent 998877 --content "Agree with this"
+confluence comment add 123456789 --parent 998877 --content "Agree with this"
 
 # Delete a comment
 confluence comment-delete 998877
@@ -467,6 +467,11 @@ confluence blog list MYSPACE
 # Get blog post details
 confluence blog get 123456789
 confluence blog get 123456789 --json
+
+# Read blog post body content
+confluence blog read 123456789
+confluence blog read 123456789 --format markdown
+confluence blog read 123456789 --format text
 
 # Create a blog post
 confluence blog create "Release Notes" MYSPACE --content "# v2.0" --format markdown
@@ -774,6 +779,7 @@ Commands are organized as grouped subcommands (`<resource> <action>`) with flat 
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
 | `blog list <space>` | List blog posts in a space | `--limit <number>`, `--json` |
 | `blog get <id>` | Get blog post details | `--json` |
+| `blog read <id>` | Read blog post body content | `--format <storage\|html\|text\|markdown>` |
 | `blog create <title> <space>` | Create a blog post | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `blog update <id>` | Update a blog post | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `blog delete <id>` | Delete a blog post | `--yes` |
@@ -787,7 +793,6 @@ Commands are organized as grouped subcommands (`<resource> <action>`) with flat 
 | `comment add <pageId>` | Create a comment on a page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`, `--parent <commentId>`, `--location <inline\|footer>`, `--inline-selection <text>`, `--inline-original-selection <text>`, `--inline-marker-ref <ref>`, `--inline-properties <json>` |
 | `comment delete <commentId>` | Delete a comment by ID | `--yes` |
 | `comments <pageId>` | Alias for `comment list` | (same options) |
-| `comment <pageId>` | Alias for `comment add` | (same options) |
 | `comment-delete <commentId>` | Alias for `comment delete` | `--yes` |
 | `attachment list <pageId>` | List attachments | `--limit`, `--pattern`, `--json` |
 | `attachment upload <pageId>` | Upload attachments | `--file`, `--comment`, `--replace` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2p2/confluence-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A TypeScript CLI for Atlassian Confluence — fork of pchuri/confluence-cli with blog posts, labels, diagnostics, and grouped commands",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client/blog.ts
+++ b/src/client/blog.ts
@@ -94,6 +94,18 @@ export class BlogClient {
     await this.httpClient.delete(`/content/${blogId}`)
   }
 
+  async readBody(blogId: string, format: 'storage' | 'view' = 'storage'): Promise<{
+    storage?: { value: string }
+    view?: { value: string }
+  }> {
+    const expand = format === 'storage' ? 'body.storage' : 'body.view'
+    const response = await this.httpClient.get<RawBlogPostResponse>(`/content/${blogId}`, { expand })
+    return {
+      storage: response.body?.storage,
+      view: response.body?.view,
+    }
+  }
+
   private normalizeBlogPost(raw: RawBlogPostResponse): BlogPostInfo {
     return {
       id: raw.id,

--- a/src/commands/blog.ts
+++ b/src/commands/blog.ts
@@ -6,6 +6,7 @@ import { HttpClient } from '../client/http';
 import { BlogClient } from '../client/blog';
 import { getConfig } from '../config';
 import { Analytics } from '../analytics';
+import { htmlToMarkdown, htmlToPlainText } from '../utils/convert';
 import { formatJson } from '../format/output';
 
 export function registerBlogCommands(program: Command): void {
@@ -75,6 +76,42 @@ export function registerBlogCommands(program: Command): void {
         analytics.track('blog_get', true);
       } catch (error) {
         analytics.track('blog_get', false);
+        console.error(chalk.red('Error:'), (error as Error).message);
+        process.exit(1);
+      }
+    });
+
+  blog
+    .command('read <id>')
+    .description('Read blog post body content')
+    .option('-f, --format <format>', 'Output format (storage, html, text, markdown)', 'storage')
+    .action(async (id: string, options: { format?: string }) => {
+      const analytics = new Analytics();
+      try {
+        const client = new BlogClient(new HttpClient(getConfig()));
+        const format = (options.format ?? 'storage').toLowerCase();
+        const apiFormat = format === 'html' || format === 'text' || format === 'markdown'
+          ? 'view'
+          : 'storage';
+        const body = await client.readBody(id, apiFormat);
+
+        let content: string;
+        if (format === 'storage') {
+          content = body.storage?.value ?? '';
+        } else if (format === 'html') {
+          content = body.view?.value ?? body.storage?.value ?? '';
+        } else if (format === 'text') {
+          content = htmlToPlainText(body.view?.value ?? body.storage?.value ?? '');
+        } else if (format === 'markdown') {
+          content = htmlToMarkdown(body.view?.value ?? body.storage?.value ?? '');
+        } else {
+          content = body.view?.value ?? body.storage?.value ?? '';
+        }
+
+        console.log(content);
+        analytics.track('blog_read', true);
+      } catch (error) {
+        analytics.track('blog_read', false);
         console.error(chalk.red('Error:'), (error as Error).message);
         process.exit(1);
       }


### PR DESCRIPTION
## Summary
- Add `blog read <id>` command with `--format` support (storage, html, text, markdown)
- Fix README: remove non-existent `comment <pageId>` alias, correct examples to use `comment add`
- Bump version to 0.1.3, update CHANGELOG with bug fixes and new feature

## Test plan
- [x] `bun dev blog read <id>` outputs storage HTML
- [x] `bun dev blog read <id> --format markdown` converts to markdown
- [x] `bun dev blog read <id> --format text` outputs plain text
- [x] `bun dev blog read <id> --format html` outputs rendered HTML