### PR TITLE
fix: convert markdown to storage format in page/blog create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For changes prior to this fork, see the [upstream changelog](https://github.com/
 - Comments list uses correct `extensions` (plural) API field for location, resolution, and inline metadata
 - Default comment location changed from "unknown" to "footer" when API doesn't return a location
 - Removed non-existent `comment <pageId>` alias from README; examples updated to use `comment add <pageId>`
+- `blog update` now includes current title in PUT payload (required by Confluence API)
+- `blog update --format markdown` and `page create/update --format markdown` now convert markdown to storage HTML before sending; `representation` always set to `storage`
 
 ## [0.1.2] - 2025-04-25
 

--- a/src/client/blog.ts
+++ b/src/client/blog.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from './http'
 import type { ContentFormat, PaginatedResponse, RawBlogPostResponse } from './types'
+import { markdownToStorage } from '../utils/convert'
 
 export interface BlogPostInfo {
   id: string;
@@ -70,20 +71,19 @@ export class BlogClient {
     const current = await this.get(blogId)
     const newVersionNumber = current.version.number + 1
 
+    const storageContent = format === 'markdown' ? markdownToStorage(content) : content
+
     const data: Record<string, unknown> = {
       id: blogId,
       type: 'blogpost',
+      title: title ?? current.title,
       version: { number: newVersionNumber },
       body: {
         storage: {
-          value: content,
-          representation: format,
+          value: storageContent,
+          representation: 'storage',
         },
       },
-    }
-
-    if (title) {
-      data.title = title
     }
 
     const response = await this.httpClient.put<RawBlogPostResponse>(`/content/${blogId}`, data)

--- a/src/client/pages.ts
+++ b/src/client/pages.ts
@@ -11,6 +11,7 @@ import type {
   RawPageResponse,
   RawChildPageResponse
 } from './types'
+import { markdownToStorage } from '../utils/convert'
 
 export interface PagesClient {
   normalizePage(data: RawPageResponse): PageInfo
@@ -130,14 +131,15 @@ export class DefaultPagesClient implements PagesClient {
     parentId?: string,
     format: ContentFormat = 'storage'
   ): Promise<CreatePageResult> {
+    const storageContent = format === 'markdown' ? markdownToStorage(content) : content
     const payload: Record<string, unknown> = {
       type: 'page',
       title,
       space: { key: spaceKey },
       body: {
         storage: {
-          value: content,
-          representation: format
+          value: storageContent,
+          representation: 'storage'
         }
       }
     }
@@ -185,14 +187,16 @@ export class DefaultPagesClient implements PagesClient {
     const currentPage = await this.readPage(id, 'storage')
     const currentVersion = currentPage.version.number
 
+    const rawContent = content || currentPage.body.storage?.value || ''
+    const storageContent = format === 'markdown' ? markdownToStorage(rawContent) : rawContent
     const payload: Record<string, unknown> = {
       type: 'page',
       title: title || currentPage.title,
       version: { number: currentVersion + 1 },
       body: {
         storage: {
-          value: content || currentPage.body.storage?.value || '',
-          representation: format
+          value: storageContent,
+          representation: 'storage'
         }
       }
     }

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -48,39 +48,44 @@ export function htmlToMarkdown(html: string): string {
  * Convert Markdown to approximate Confluence storage format.
  */
 export function markdownToStorage(markdown: string): string {
-  let storage = markdown;
-  storage = storage.replace(/^######\s+(.+)$/gm, '<h6>$1</h6>');
-  storage = storage.replace(/^#####\s+(.+)$/gm, '<h5>$1</h5>');
-  storage = storage.replace(/^####\s+(.+)$/gm, '<h4>$1</h4>');
-  storage = storage.replace(/^###\s+(.+)$/gm, '<h3>$1</h3>');
-  storage = storage.replace(/^##\s+(.+)$/gm, '<h2>$1</h2>');
-  storage = storage.replace(/^#\s+(.+)$/gm, '<h1>$1</h1>');
-  storage = storage.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-  storage = storage.replace(/\*(.+?)\*/g, '<em>$1</em>');
-  storage = storage.replace(/`(.+?)`/g, '<code>$1</code>');
-  storage = storage.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-  storage = storage.replace(/^---$/gm, '<hr/>');
-  storage = storage.replace(/\n{2,}/g, '</p><p>');
-  return `<p>${storage}</p>`;
+  const blocks = splitBlocks(markdown);
+  return blocks.map(block => {
+    const html = applyInlineFormatting(block);
+    if (/^<h[1-6]>|^<hr\/>/.test(html)) return html;
+    return `<p>${html}</p>`;
+  }).join('');
 }
 
 /**
  * Convert Markdown to HTML.
  */
 export function markdownToHtml(markdown: string): string {
-  let html = markdown;
-  html = html.replace(/^######\s+(.+)$/gm, '<h6>$1</h6>');
-  html = html.replace(/^#####\s+(.+)$/gm, '<h5>$1</h5>');
-  html = html.replace(/^####\s+(.+)$/gm, '<h4>$1</h4>');
-  html = html.replace(/^###\s+(.+)$/gm, '<h3>$1</h3>');
-  html = html.replace(/^##\s+(.+)$/gm, '<h2>$1</h2>');
-  html = html.replace(/^#\s+(.+)$/gm, '<h1>$1</h1>');
+  const blocks = splitBlocks(markdown);
+  return blocks.map(block => {
+    let html = applyInlineFormatting(block);
+    html = html.replace(/\n/g, '<br/>');
+    if (/^<h[1-6]>|^<hr\/>/.test(html)) return html;
+    return `<p>${html}</p>`;
+  }).join('');
+}
+
+function splitBlocks(markdown: string): string[] {
+  let text = markdown;
+  text = text.replace(/^######\s+(.+)$/gm, '<h6>$1</h6>');
+  text = text.replace(/^#####\s+(.+)$/gm, '<h5>$1</h5>');
+  text = text.replace(/^####\s+(.+)$/gm, '<h4>$1</h4>');
+  text = text.replace(/^###\s+(.+)$/gm, '<h3>$1</h3>');
+  text = text.replace(/^##\s+(.+)$/gm, '<h2>$1</h2>');
+  text = text.replace(/^#\s+(.+)$/gm, '<h1>$1</h1>');
+  text = text.replace(/^---$/gm, '<hr/>');
+  return text.split(/\n{2,}/).filter(Boolean);
+}
+
+function applyInlineFormatting(text: string): string {
+  let html = text;
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
   html = html.replace(/`(.+?)`/g, '<code>$1</code>');
   html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-  html = html.replace(/^---$/gm, '<hr/>');
-  html = html.replace(/\n{2,}/g, '</p><p>');
-  html = html.replace(/\n/g, '<br/>');
-  return `<p>${html}</p>`;
+  return html;
 }


### PR DESCRIPTION
## Summary
- Fix `blog update` missing title in PUT payload (required by Confluence API)
- Fix markdown content not being converted to storage HTML before sending — affects `blog update`, `page create`, `page update`
- Set `representation` to `'storage'` always (Confluence doesn't accept `'markdown'` or `'html'` as representation values)

## Test plan
- [x] `bun dev blog update <id> --content "# Test" --format markdown` succeeds
- [x] `bun dev blog update <id> --content "updated" --format storage` still works
- [x] `bun dev page create "Title" SPACE --content "# Test" --format markdown` creates page with converted content