### PR TITLE
fix: rename label remove to label delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For changes prior to this fork, see the [upstream changelog](https://github.com/
 - Removed non-existent `comment <pageId>` alias from README; examples updated to use `comment add <pageId>`
 - `blog update` now includes current title in PUT payload (required by Confluence API)
 - `blog update --format markdown` and `page create/update --format markdown` now convert markdown to storage HTML before sending; `representation` always set to `storage`
+- Renamed `label remove` to `label delete` for consistency with other commands (`comment delete`, `attachment delete`, `property delete`)
 
 ## [0.1.2] - 2025-04-25
 

--- a/README.md
+++ b/README.md
@@ -494,8 +494,8 @@ confluence label list 123456789 --json
 # Add a label
 confluence label add 123456789 meeting-notes
 
-# Remove a label
-confluence label remove 123456789 meeting-notes
+# Delete a label
+confluence label delete 123456789 meeting-notes
 ```
 
 ### Diagnostics
@@ -785,7 +785,7 @@ Commands are organized as grouped subcommands (`<resource> <action>`) with flat 
 | `blog delete <id>` | Delete a blog post | `--yes` |
 | `label list <pageId>` | List labels on a page | `--json` |
 | `label add <pageId> <name>` | Add a label to a page | |
-| `label remove <pageId> <name>` | Remove a label from a page | |
+| `label delete <pageId> <name>` | Delete a label from a page | |
 | `attachments <pageId_or_url>` | List or download attachments for a page | `--limit <number>`, `--pattern <glob>`, `--download`, `--dest <directory>` |
 | `attachment-upload <pageId_or_url>` | Upload attachments to a page | `--file <path>`, `--comment <text>`, `--replace`, `--minor-edit` |
 | `attachment-delete <pageId_or_url> <attachmentId>` | Delete an attachment from a page | `--yes` |

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -56,17 +56,17 @@ export function registerLabelCommands(program: Command): void {
     });
 
   label
-    .command('remove <pageId> <name>')
-    .description('Remove a label from a page')
+    .command('delete <pageId> <name>')
+    .description('Delete a label from a page')
     .action(async (pageId: string, name: string) => {
       const analytics = new Analytics();
       try {
         const client = new DefaultLabelsClient(new HttpClient(getConfig()));
         await client.remove(pageId, name);
-        console.log(chalk.green(`Label "${name}" removed from page ${pageId}.`));
-        analytics.track('label_remove', true);
+        console.log(chalk.green(`Label "${name}" deleted from page ${pageId}.`));
+        analytics.track('label_delete', true);
       } catch (error) {
-        analytics.track('label_remove', false);
+        analytics.track('label_delete', false);
         console.error(chalk.red('Error:'), (error as Error).message);
         process.exit(1);
       }


### PR DESCRIPTION
## Summary
- Rename `label remove` to `label delete` for consistency with all other delete commands (comment, attachment, property, blog, page)
- Update README examples and commands table

## Test plan
- [x] `bun dev label delete <pageId> <name>` deletes a label
- [x] `bun dev label list <pageId>` still works
- [x] `bun dev label add <pageId> <name>` still works