### PR TITLE
fix: find shows space and URL, resolve site URLs correctly, bump to
0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [0.1.4] - 2026-04-26
+
+### Added
+
+- `find` command now shows space name and page URL in results
+- `find` command accepts `--type` option to search for pages, blog posts, comments, or attachments
+
+### Fixed
+
+- URLs in `find`, `create`, `create-child`, `update`, and `blog get` now use the actual site URL instead of the API domain (fixes scoped API token setups)
+- `markdownToStorage` no longer wraps block elements (headings, hr) in `<p>` tags, which produced empty `<p />` artifacts in Confluence
+
 ## [0.1.3] - 2025-04-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2p2/confluence-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A TypeScript CLI for Atlassian Confluence — fork of pchuri/confluence-cli with blog posts, labels, diagnostics, and grouped commands",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client/pages.ts
+++ b/src/client/pages.ts
@@ -291,10 +291,12 @@ export class DefaultPagesClient implements PagesClient {
     spaceKey?: string,
     type: SearchType = 'page'
   ): Promise<PageInfo[]> {
+    const apiType = type === 'blog' ? 'blogpost' : type
     const params: Record<string, unknown> = {
       limit: 50,
-      type,
-      title
+      type: apiType,
+      title,
+      expand: 'space,version',
     }
 
     if (spaceKey) {

--- a/src/commands/blog.ts
+++ b/src/commands/blog.ts
@@ -66,10 +66,9 @@ export function registerBlogCommands(program: Command): void {
           console.log(`  Space:  ${chalk.green(`${post.space.name} (${post.space.key})`)}`);
           console.log(`  Version: ${chalk.green(String(post.version.number))}`);
           if (post._links?.webui) {
-            const base = post._links.base ?? '';
             const url = post._links.webui.startsWith('http')
               ? post._links.webui
-              : `${base}${post._links.webui}`;
+              : `${post._links.base ?? post._links.self?.replace(/\/rest\/api.*$/, '') ?? ''}${post._links.webui}`;
             console.log(`  URL:    ${chalk.cyan(url)}`);
           }
         }

--- a/src/commands/pages/crud.ts
+++ b/src/commands/pages/crud.ts
@@ -21,6 +21,13 @@ export function buildClient(config: ReturnType<typeof getConfig>) {
   };
 }
 
+export function resolveUrl(links: { base?: string; self?: string; webui?: string }): string {
+  if (!links.webui) return '';
+  if (links.webui.startsWith('http')) return links.webui;
+  const base = links.base ?? links.self?.replace(/\/rest\/api.*$/, '') ?? '';
+  return `${base}${links.webui}`;
+}
+
 export function pageUrl(
   config: ReturnType<typeof getConfig>,
   spaceKey: string,
@@ -99,7 +106,7 @@ export async function handleCreate(title: string, space: string, options: {
   );
 
   const url = result._links?.webui
-    ? http.buildUrl(result._links.webui)
+    ? resolveUrl(result._links)
     : pageUrl(config, result.space.key, result.id);
 
   console.log(chalk.green('Page created successfully!'));
@@ -142,7 +149,7 @@ export async function handleCreateChild(
   );
 
   const url = result._links?.webui
-    ? http.buildUrl(result._links.webui)
+    ? resolveUrl(result._links)
     : pageUrl(config, result.space.key, result.id);
 
   console.log(chalk.green('Child page created successfully!'));
@@ -209,7 +216,7 @@ export async function handleUpdate(pageId: string, options: {
   );
 
   const url = result._links?.webui
-    ? http.buildUrl(result._links.webui)
+    ? resolveUrl(result._links)
     : pageUrl(config, result.space.key, result.id);
 
   console.log(chalk.green('Page updated successfully!'));

--- a/src/commands/pages/index.ts
+++ b/src/commands/pages/index.ts
@@ -14,6 +14,7 @@ import {
   handleMove,
   handlePageList,
   buildClient,
+  resolveUrl,
 } from './crud.js';
 import { handleChildren, buildTree, shouldExcludePage, copyPageTree, type TreeNode } from './tree.js';
 import { handleExport } from './export.js';
@@ -133,15 +134,16 @@ export function registerPageCommands(program: Command): void {
   // find
   program
     .command('find <title>')
-    .description('Find a page by title')
+    .description('Find content by title')
     .option('-s, --space <spaceKey>', 'Limit search to specific space')
-    .action(async (title: string, options: { space?: string }) => {
+    .option('--type <type>', 'Content type (page, blog, comment, attachment)', 'page')
+    .action(async (title: string, options: { space?: string; type?: string }) => {
       const analytics = new Analytics();
       try {
         const config = getConfig();
         const { pages } = buildClient(config);
 
-        const results = await pages.findPageByTitle(title, options.space);
+        const results = await pages.findPageByTitle(title, options.space, options.type as any);
 
         if (results.length === 0) {
           console.log(chalk.yellow('No pages found.'));
@@ -155,6 +157,9 @@ export function registerPageCommands(program: Command): void {
           console.log(`ID: ${chalk.green(info.id)}`);
           if (info.space) {
             console.log(`Space: ${chalk.green(info.space.name)} (${info.space.key})`);
+          }
+          if (info._links?.webui) {
+            console.log(`URL: ${chalk.cyan(resolveUrl(info._links))}`);
           }
         }
         analytics.track('find', true);


### PR DESCRIPTION
## Summary
- The `find` command was missing `expand: 'space'` in its API call, so results had no space data and displayed empty `Space:  ()`

## Test plan
- [ ] `bun dev find "some page title"` shows space name and key