### PR TITLE
fix: add folder/file icons to children tree format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ For changes prior to this fork, see the [upstream changelog](https://github.com/
 
 ### Fixed
 
-- URLs in `find`, `create`, `create-child`, `update`, and `blog get` now use the actual site URL instead of the API domain (fixes scoped API token setups)
+- URLs in `find`, `create`, `create-child`, `update`, `blog get`, and `children` now use the actual site URL instead of the API domain (fixes scoped API token setups)
 - `markdownToStorage` no longer wraps block elements (headings, hr) in `<p>` tags, which produced empty `<p />` artifacts in Confluence
+- `children --recursive --format tree` now correctly nests children under their parent (was flat list)
+- `children --recursive --format tree` shows 📁/📄 icons matching the Rust CLI
 
 ## [0.1.3] - 2025-04-25
 

--- a/src/client/pages.ts
+++ b/src/client/pages.ts
@@ -261,6 +261,7 @@ export class DefaultPagesClient implements PagesClient {
       const children = await this.getChildPages(parentId)
 
       for (const child of children) {
+        child.parentId = parentId
         allPages.push(child)
         await fetchChildren(child.id)
       }

--- a/src/commands/pages/tree.ts
+++ b/src/commands/pages/tree.ts
@@ -3,7 +3,7 @@ import type { Analytics } from '../../analytics.js';
 import { HttpClient } from '../../client/http.js';
 import type { PagesClient } from '../../client/pages.js';
 import { getConfig } from '../../config/loader.js';
-import { buildClient, pageUrl } from './crud.js';
+import { buildClient, resolveUrl, pageUrl } from './crud.js';
 
 export interface TreeNode {
   id: string;
@@ -53,7 +53,7 @@ export function printTreeNodes(
   nodes: TreeNode[],
   http: HttpClient,
   config: ReturnType<typeof getConfig>,
-  options: { showId?: boolean; showUrl?: boolean },
+  options: { showId?: boolean; showUrl?: boolean; baseUrl?: string },
   depth: number,
 ): void {
   for (let i = 0; i < nodes.length; i++) {
@@ -61,11 +61,13 @@ export function printTreeNodes(
     const isLast = i === nodes.length - 1;
     const indent = '  '.repeat(depth - 1);
     const prefix = isLast ? '└── ' : '├── ';
+    const hasChildren = node.children?.length > 0;
+    const icon = hasChildren ? '📁' : '📄';
 
-    let output = `${indent}${prefix}${chalk.green(node.title)}`;
+    let output = `${indent}${prefix}${icon} ${chalk.green(node.title)}`;
     if (options.showId) output += ` ${chalk.gray(`(ID: ${node.id})`)}`;
-    if (options.showUrl && node.space?.key) {
-      const url = pageUrl(config, node.space.key, node.id);
+    if (options.showUrl && options.baseUrl && node.space?.key) {
+      const url = `${options.baseUrl}/spaces/${node.space.key}/pages/${node.id}`;
       output += `\n${indent}${isLast ? '    ' : '│   '}${chalk.gray(url)}`;
     }
     console.log(output);
@@ -185,12 +187,15 @@ export async function handleChildren(pageId: string, options: {
     }, null, 2));
   } else if (format === 'tree' && options.recursive) {
     const pageInfo = await pages.getPageInfo(pageId);
-    console.log(chalk.blue(`* ${pageInfo.title}`));
+    const baseUrl = pageInfo._links?.base ?? pageInfo._links?.self?.replace(/\/rest\/api.*$/, '') ?? '';
+    console.log(chalk.blue(`📁 ${pageInfo.title}`));
     const tree = buildTree(children, pageId);
-    printTreeNodes(tree, http, config, options, 1);
+    printTreeNodes(tree, http, config, { ...options, baseUrl }, 1);
     console.log('');
     console.log(chalk.gray(`Total: ${children.length} child page(s)`));
   } else {
+    const pageInfo = await pages.getPageInfo(pageId);
+    const baseUrl = pageInfo._links?.base ?? pageInfo._links?.self?.replace(/\/rest\/api.*$/, '') ?? '';
     console.log(chalk.blue('Child pages:'));
     console.log('');
     for (let i = 0; i < children.length; i++) {
@@ -198,7 +203,7 @@ export async function handleChildren(pageId: string, options: {
       let output = `${i + 1}. ${chalk.green(page.title)}`;
       if (options.showId) output += ` ${chalk.gray(`(ID: ${page.id})`)}`;
       if (options.showUrl && page.space?.key) {
-        const url = pageUrl(config, page.space.key, page.id);
+        const url = `${baseUrl}/spaces/${page.space.key}/pages/${page.id}`;
         output += `\n   ${chalk.gray(url)}`;
       }
       if (options.recursive && page.parentId && page.parentId !== pageId) {


### PR DESCRIPTION
## Summary
- Root node shows 📁, leaf pages show 📄, parent nodes with children show 📁
- Replaces bare `*` prefix on root with 📁

## Test plan
- [x] `bun dev children <id> --recursive --format tree` shows icons
- [x] `bun dev children <id> --recursive --format tree --show-id` shows icons + IDs