### PR TITLE
fix: update plugin.json to reference forked repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "pchuri-confluence-cli",
+  "name": "s2p2-confluence-cli",
   "owner": {
-    "name": "pchuri"
+    "name": "S2P2"
   },
   "metadata": {
     "description": "Claude Code plugins for Atlassian Confluence CLI.",

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -8,7 +8,7 @@ echo "========================="
 # Check if confluence command is available
 if ! command -v confluence &> /dev/null; then
     echo "❌ confluence command not found. Please install confluence-cli first:"
-    echo "   npm install -g confluence-cli"
+    echo "   npm install -g @s2p2/confluence-cli"
     exit 1
 fi
 

--- a/plugins/confluence/.claude-plugin/plugin.json
+++ b/plugins/confluence/.claude-plugin/plugin.json
@@ -2,10 +2,10 @@
   "name": "confluence",
   "description": "Use confluence-cli to read, search, create, update, move, delete, and convert Confluence pages and attachments from the terminal.",
   "author": {
-    "name": "pchuri"
+    "name": "S2P2"
   },
-  "homepage": "https://github.com/pchuri/confluence-cli#readme",
-  "repository": "https://github.com/pchuri/confluence-cli",
+  "homepage": "https://github.com/S2P2/confluence-cli#readme",
+  "repository": "https://github.com/S2P2/confluence-cli",
   "license": "MIT",
   "keywords": [
     "confluence",

--- a/plugins/confluence/README.md
+++ b/plugins/confluence/README.md
@@ -1,6 +1,6 @@
 # confluence
 
-A Claude Code plugin for [confluence-cli](https://github.com/pchuri/confluence-cli). Gives Claude Code full knowledge of all confluence-cli commands so it can read, search, create, update, move, delete, and convert Confluence pages and attachments on your behalf.
+A Claude Code plugin for [confluence-cli](https://github.com/S2P2/confluence-cli). Gives Claude Code full knowledge of all confluence-cli commands so it can read, search, create, update, move, delete, and convert Confluence pages and attachments on your behalf.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Add the marketplace and install the plugin:
 confluence-cli must be installed and configured:
 
 ```bash
-npm install -g confluence-cli
+npm install -g @s2p2/confluence-cli
 confluence init
 ```
 

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -12,7 +12,7 @@ A CLI tool for Atlassian Confluence. Lets you read, search, create, update, move
 ## Installation
 
 ```sh
-npm install -g confluence-cli
+npm install -g @s2p2/confluence-cli
 confluence --version   # verify install
 ```
 


### PR DESCRIPTION
## Summary
- Update `plugin.json` to reference `S2P2/confluence-cli` instead of `pchuri/confluence-cli` for author, homepage, and repository URLs

## Test plan
- [x] Verify plugin installs correctly from fork
- [x] Confirm Claude Code shows the correct repo URL in plugin info