### PR TITLE
fix: inline package.json import so bin resolves correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [0.1.5] - 2026-04-26
+
+### Fixed
+
+- Plugin `plugin.json` and `marketplace.json` now reference the forked repo (`S2P2/confluence-cli`) instead of the original
+- Installation instructions updated to `npm install -g @s2p2/confluence-cli`
+- `confluence` binary now resolves `package.json` correctly by inlining it at build time (was broken by relative path from `dist/bin/`)
+
 ## [0.1.4] - 2026-04-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "confluence-cli",
-  "version": "1.33.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "confluence-cli",
-      "version": "1.33.0",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2p2/confluence-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A TypeScript CLI for Atlassian Confluence — fork of pchuri/confluence-cli with blog posts, labels, diagnostics, and grouped commands",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,10 +13,7 @@ import { registerConvertCommand } from './commands/convert';
 import { initConfig } from './config';
 import { Analytics } from './analytics';
 import chalk from 'chalk';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const pkg = require('../package.json');
+import pkg from '../package.json';
 
 export function createProgram(): Command {
   const program = new Command();


### PR DESCRIPTION
## Summary
- Replace `createRequire(import.meta.url)` + runtime `require('../package.json')` with a static JSON import that tsup inlines at build time
- Fixes `dist/bin/confluence.js` failing to find `package.json` because the relative path was wrong from the nested output location

## Test plan
- [ ] `bun run build` succeeds
- [ ] `node dist/bin/confluence.js --version` prints the correct version
- [ ] `npm install -g .` works and `confluence --version` prints correct version