### PR TITLE
fix(ci): use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
-        node-version: '22'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
 
     - run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Bump Node version from 22 to 24 in the publish job so npm 11.5.1+ is available (required for OIDC trusted publishing)

## Test plan
- Merge, then re-create the v0.1.7 release to trigger the publish workflow
- Verify OIDC publish succeeds and 0.1.7 appears on npmjs.com