### PR TITLE
fix(ci): remove registry-url for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,12 @@ jobs:
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: '24'
-        registry-url: 'https://registry.npmjs.org'
 
     - run: bun install --frozen-lockfile
     - run: bun run build
 
-    - name: Publish to npm
+    - name: Verify npm version (trusted publishing requires 11.5.1+)
+      run: npm --version
+
+    - name: Publish to npm via OIDC trusted publishing
       run: npm publish --access public


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` in publish job — it creates an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` which interferes with npm CLI's OIDC auto-detection
- Add npm version check step to verify npm >= 11.5.1 (trusted publishing requirement)

## Test plan
- Merge, delete v0.1.7 release, re-create it to trigger publish
- Verify npm CLI detects OIDC environment and publishes successfully