### PR TITLE
fix(ci): upgrade npm to latest for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
       with:
         node-version: '24'
 
+    - name: Upgrade npm for trusted publishing (requires 11.5.1+)
+      run: npm install -g npm@latest && npm --version
+
     - run: bun install --frozen-lockfile
     - run: bun run build
-
-    - name: Verify npm version (trusted publishing requires 11.5.1+)
-      run: npm --version
 
     - name: Publish to npm via OIDC trusted publishing
       run: npm publish --access public


### PR DESCRIPTION
## Summary
- Node 24 ships with npm 10.x, but trusted publishing requires npm 11.5.1+
- Add step to upgrade npm globally before publishing

## Test plan
- Merge, delete v0.1.7 release, re-create to trigger publish
- Verify npm >= 11.5.1 in logs and OIDC publish succeeds