### PR TITLE
feat: add service-account auth type with auto cloud ID fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
-## [Unreleased]
+## [0.1.8] - 2026-04-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [Unreleased]
+
+### Added
+
+- `service-account` auth type for Atlassian service account tokens (ATSTT). `confluence init` now offers a `service-account` choice that auto-fetches the cloud ID from `/_edge/tenant_info` and configures the `api.atlassian.com` gateway with the correct API path.
+- `siteUrl` profile field stores the original site domain for correct page link generation when using the API gateway.
+- `CONFLUENCE_SITE_URL` environment variable for overriding the site URL.
+
+### Fixed
+
+- `normalizeProfileConfig` now preserves nested `auth` objects from config.json instead of discarding them. Previously, the loader always reconstructed auth from flat fields (`authType`, `token` at top level), losing the token when the config used the nested `auth: { type, token }` format written by `initConfig`.
+- `pageUrl` in page commands now uses `siteUrl` (original domain) when available, producing correct page links for service-account profiles where `domain` is `api.atlassian.com`.
+
 ## [0.1.5] - 2026-04-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This creates `.claude/skills/confluence/SKILL.md` in your current directory. Cla
 confluence init
 ```
 
-The wizard helps you choose the right API endpoint and authentication method. It recommends `/wiki/rest/api` for Atlassian Cloud domains (e.g., `*.atlassian.net`) and `/rest/api` for self-hosted/Data Center instances, then prompts for Basic (email/username + token/password), Bearer, or client-certificate (mTLS) authentication.
+The wizard helps you choose the right API endpoint and authentication method. It recommends `/wiki/rest/api` for Atlassian Cloud domains (e.g., `*.atlassian.net`) and `/rest/api` for self-hosted/Data Center instances, then prompts for Basic (email/username + token/password), Service Account (ATSTT token), Bearer (PAT for Data Center), or client-certificate (mTLS) authentication. When Service Account is selected for a Cloud domain, it auto-fetches the cloud ID from `/_edge/tenant_info` and configures the `api.atlassian.com` gateway.
 
 ### Option 2: Non-interactive Setup (CLI Flags)
 
@@ -116,7 +116,16 @@ confluence init \
   --token "your-api-token"
 ```
 
-**Scoped API token** (recommended for agents — least privilege):
+**Service account** (recommended for agents — auto-configures gateway):
+```bash
+# Just provide your site domain and ATSTT token — cloud ID is fetched automatically
+confluence init \
+  --domain "yourcompany.atlassian.net" \
+  --auth-type "service-account" \
+  --token "ATSTT..."
+```
+
+**Scoped API token** (manual gateway configuration):
 ```bash
 # Replace <your-cloud-id> with your actual Cloud ID
 confluence init \
@@ -174,7 +183,7 @@ confluence init --email "user@example.com" --token "your-api-token"
 **Available flags:**
 - `-d, --domain <domain>` - Confluence domain (e.g., `company.atlassian.net`)
 - `-p, --api-path <path>` - REST API path (e.g., `/wiki/rest/api`)
-- `-a, --auth-type <type>` - Authentication type: `basic`, `bearer`, `mtls`, or `cookie`
+- `-a, --auth-type <type>` - Authentication type: `basic`, `service-account`, `bearer`, `mtls`, or `cookie`
 - `-e, --email <email>` - Email or username for basic authentication
 - `-t, --token <token>` - API token or password
 - `-c, --cookie <cookie>` - Cookie for Enterprise SSO authentication (e.g., `"JSESSIONID=..."`)
@@ -191,7 +200,7 @@ export CONFLUENCE_DOMAIN="your-domain.atlassian.net"
 export CONFLUENCE_API_TOKEN="your-api-token"      # or password for on-premise (alias: CONFLUENCE_PASSWORD)
 export CONFLUENCE_EMAIL="your.email@example.com"  # required for basic auth (alias: CONFLUENCE_USERNAME for on-premise)
 export CONFLUENCE_API_PATH="/wiki/rest/api"         # Cloud default; use /rest/api for Server/DC
-# Optional: set to 'bearer' for self-hosted/Data Center instances
+# Optional: set to 'bearer' for self-hosted/Data Center, 'service-account' for ATSTT tokens
 export CONFLUENCE_AUTH_TYPE="basic"
 # Optional: select a named profile (overridden by --profile flag)
 export CONFLUENCE_PROFILE="default"
@@ -215,13 +224,13 @@ export CONFLUENCE_AUTH_TYPE="cookie"
 export CONFLUENCE_COOKIE="JSESSIONID=abc123xyz..."
 ```
 
-**Scoped API token** (recommended for agents):
+**Service account** (recommended for agents):
 ```bash
 export CONFLUENCE_DOMAIN="api.atlassian.com"
 export CONFLUENCE_API_PATH="/ex/confluence/<your-cloud-id>/wiki/rest/api"
-export CONFLUENCE_AUTH_TYPE="basic"
-export CONFLUENCE_EMAIL="user@example.com"
-export CONFLUENCE_API_TOKEN="your-scoped-token"
+export CONFLUENCE_AUTH_TYPE="service-account"
+export CONFLUENCE_API_TOKEN="ATSTT..."
+export CONFLUENCE_SITE_URL="https://yourcompany.atlassian.net"
 ```
 
 `CONFLUENCE_API_PATH` defaults to `/wiki/rest/api` for Atlassian Cloud domains and `/rest/api` otherwise. Override it when your site lives under a custom reverse proxy or on-premises path. `CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise. For `mtls`, set `CONFLUENCE_TLS_CLIENT_CERT` and `CONFLUENCE_TLS_CLIENT_KEY`; `CONFLUENCE_TLS_CA_CERT` is optional.
@@ -285,7 +294,24 @@ When set, all write operations (`create`, `update`, `delete`, etc.) are blocked 
 3. Give it a label (e.g., "confluence-cli")
 4. Copy the generated token
 
-**Atlassian Cloud — Scoped API Token** (recommended for agents and automation):
+**Atlassian Cloud — Service Account** (recommended for agents and automation):
+
+Service accounts use ATSTT tokens via the `api.atlassian.com` gateway. The `service-account` auth type auto-fetches the cloud ID from `/_edge/tenant_info` and configures the correct API path.
+
+1. Go to [Atlassian Admin](https://admin.atlassian.com) → Directory → Service accounts
+2. Click **Create credentials → API token**
+3. Select scopes (see below). You need both Classic (v1) and Granular (v2) scopes.
+4. Configure with:
+   ```bash
+   confluence init \
+     --domain "yourcompany.atlassian.net" \
+     --auth-type "service-account" \
+     --token "ATSTT..."
+   ```
+
+The CLI automatically fetches the cloud ID and configures `api.atlassian.com` as the gateway.
+
+**Atlassian Cloud — Scoped API Token** (manual gateway configuration):
 
 Scoped tokens restrict access to specific Atlassian products and permissions, following the principle of least privilege. They use a different API gateway (`api.atlassian.com`) instead of your site domain.
 
@@ -296,7 +322,7 @@ Scoped tokens restrict access to specific Atlassian products and permissions, fo
    - **API path:** `/ex/confluence/<your-cloud-id>/wiki/rest/api`
    - **Auth type:** `basic` (email + scoped token)
 
-**Required scopes for scoped API tokens:**
+**Required scopes for service accounts and scoped API tokens:**
 
 When creating a scoped token, select the following [classic scopes](https://developer.atlassian.com/cloud/confluence/scopes-for-oauth-2-3LO-and-forge-apps/) based on your needs:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s2p2/confluence-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A TypeScript CLI for Atlassian Confluence — fork of pchuri/confluence-cli with blog posts, labels, diagnostics, and grouped commands",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -57,12 +57,13 @@ Most commands support `--json` for machine-readable output.
 |---|---|---|
 | `CONFLUENCE_DOMAIN` | Your Confluence hostname | `company.atlassian.net` |
 | `CONFLUENCE_API_PATH` | REST API base path | `/wiki/rest/api` (Cloud) or `/rest/api` (Server/DC) |
-| `CONFLUENCE_AUTH_TYPE` | `basic` or `bearer` | `basic` |
+| `CONFLUENCE_AUTH_TYPE` | `basic`, `service-account`, `bearer`, `mtls`, or `cookie` | `basic` |
 | `CONFLUENCE_EMAIL` | Email address (basic auth only) | `user@company.com` |
 | `CONFLUENCE_API_TOKEN` | API token or personal access token | `ATATT3x...` |
 | `CONFLUENCE_PROFILE` | Named profile to use (optional) | `staging` |
 | `CONFLUENCE_READ_ONLY` | Block all write operations when `true` | `true` |
 | `CONFLUENCE_FORCE_CLOUD` | Force Cloud link format for custom domains | `true` |
+| `CONFLUENCE_SITE_URL` | Original site URL (for service-account profiles) | `https://company.atlassian.net` |
 | `CONFLUENCE_LINK_STYLE` | Override link rendering: `smart`, `plain`, or `wiki` | `plain` |
 
 **Global `--profile` flag (use a named profile for any command):**
@@ -88,18 +89,29 @@ confluence init \
 
 **Cloud vs Server/DC:**
 - Atlassian Cloud (`*.atlassian.net`): use `--api-path "/wiki/rest/api"`, auth type `basic` with email + API token
+- Atlassian Cloud (service account): use `--domain "yourcompany.atlassian.net" --auth-type "service-account" --token "ATSTT..."`. The CLI auto-fetches the cloud ID from `/_edge/tenant_info` and configures the `api.atlassian.com` gateway. Recommended for agents (least privilege).
 - Atlassian Cloud (custom domain): if your Cloud instance uses a custom domain (e.g., `wiki.example.org`), set `CONFLUENCE_FORCE_CLOUD=true` or add `"forceCloud": true` to your profile in `~/.confluence-cli/config.json`. Without this, links will render incorrectly.
-- Atlassian Cloud (scoped token): use `--domain "api.atlassian.com"`, `--api-path "/ex/confluence/<your-cloud-id>/wiki/rest/api"`, auth type `basic` with email + scoped token. Get your Cloud ID from `https://<your-site>.atlassian.net/_edge/tenant_info`. Recommended for agents (least privilege).
+- Atlassian Cloud (scoped token, manual): use `--domain "api.atlassian.com"`, `--api-path "/ex/confluence/<your-cloud-id>/wiki/rest/api"`, auth type `basic` with email + scoped token. Get your Cloud ID from `https://<your-site>.atlassian.net/_edge/tenant_info`.
 - Self-hosted / Data Center: use `--api-path "/rest/api"`, auth type `bearer` with a personal access token (no email needed)
 
-**Scoped API token for agents (recommended):**
+**Service account for agents (recommended):**
+
+```sh
+# Non-interactive init — cloud ID fetched automatically
+confluence init \
+  --domain "yourcompany.atlassian.net" \
+  --auth-type "service-account" \
+  --token "ATSTT..."
+```
+
+Or via environment variables (manual gateway configuration):
 
 ```sh
 export CONFLUENCE_DOMAIN="api.atlassian.com"
 export CONFLUENCE_API_PATH="/ex/confluence/<your-cloud-id>/wiki/rest/api"
-export CONFLUENCE_AUTH_TYPE="basic"
-export CONFLUENCE_EMAIL="user@company.com"
-export CONFLUENCE_API_TOKEN="your-scoped-token"
+export CONFLUENCE_AUTH_TYPE="service-account"
+export CONFLUENCE_API_TOKEN="ATSTT..."
+export CONFLUENCE_SITE_URL="https://yourcompany.atlassian.net"
 ```
 
 Required classic scopes for scoped tokens:
@@ -167,7 +179,7 @@ confluence read "https://company.atlassian.net/wiki/spaces/MYSPACE/pages/1234567
 Initialize configuration. Saves credentials to `~/.confluence-cli/config.json`.
 
 ```sh
-confluence init [--domain <domain>] [--api-path <path>] [--auth-type basic|bearer] [--email <email>] [--token <token>] [--read-only]
+confluence init [--domain <domain>] [--api-path <path>] [--auth-type basic|service-account|bearer|mtls|cookie] [--email <email>] [--token <token>] [--read-only]
 ```
 
 All flags are optional; omitting any flag triggers an interactive prompt for that field. Provide all flags to run fully non-interactive. Use the global `--profile` flag to save to a named profile:
@@ -789,7 +801,7 @@ confluence profile use staging
 Add a new configuration profile. Supports the same options as `init` (interactive, non-interactive, or hybrid).
 
 ```sh
-confluence profile add <name> [--domain <domain>] [--api-path <path>] [--auth-type basic|bearer] [--email <email>] [--token <token>] [--protocol http|https] [--read-only]
+confluence profile add <name> [--domain <domain>] [--api-path <path>] [--auth-type basic|service-account|bearer|mtls|cookie] [--email <email>] [--token <token>] [--protocol http|https] [--read-only]
 ```
 
 Profile names may contain letters, numbers, hyphens, and underscores only.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ export function createProgram(): Command {
     .option('-d, --domain <domain>', 'Confluence domain')
     .option('--protocol <protocol>', 'Protocol (http or https)')
     .option('-p, --api-path <path>', 'REST API path')
-    .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, mtls, cookie)')
+    .option('-a, --auth-type <type>', 'Authentication type (basic, service-account, bearer, mtls, cookie)')
     .option('-e, --email <email>', 'Email or username for basic auth')
     .option('-t, --token <token>', 'API token')
     .option('-c, --cookie <cookie>', 'Cookie for Enterprise SSO')

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -63,6 +63,7 @@ export class HttpClient {
         break
       }
       case 'bearer':
+      case 'service-account':
         headers.Authorization = `Bearer ${this.config.token}`
         break
       case 'cookie':

--- a/src/commands/pages/crud.ts
+++ b/src/commands/pages/crud.ts
@@ -29,7 +29,8 @@ export function resolveUrl(links: { base?: string; self?: string; webui?: string
 }
 
 export function pageUrl(config: ReturnType<typeof getConfig>, spaceKey: string, pageId: string): string {
-  return `${config.protocol}://${config.domain}/wiki${config.apiPath.replace('/rest/api', '')}/spaces/${spaceKey}/pages/${pageId}`
+  const siteDomain = config.siteUrl ? config.siteUrl.replace(/^https?:\/\//, '') : config.domain
+  return `${config.protocol}://${siteDomain}/wiki${config.apiPath.replace('/rest/api', '')}/spaces/${spaceKey}/pages/${pageId}`
 }
 
 export async function handleRead(pageId: string, options: { format: string }, analytics: Analytics): Promise<void> {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-export { CONFIG_DIR, CONFIG_FILE, getConfig, loadConfig, normalizeApiPath, normalizeProtocol } from './loader'
+export { CONFIG_DIR, CONFIG_FILE, fetchCloudId, getConfig, loadConfig, normalizeApiPath, normalizeProtocol } from './loader'
 export { deleteProfile, initConfig, isValidProfileName, listProfiles, setActiveProfile } from './profiles'
 export type {
   AppConfig,
@@ -9,4 +9,5 @@ export type {
   MtlsAuthConfig,
   ProfileConfig,
   ResolvedConfig,
+  ServiceAccountAuthConfig,
 } from './types'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,12 @@
-export { CONFIG_DIR, CONFIG_FILE, fetchCloudId, getConfig, loadConfig, normalizeApiPath, normalizeProtocol } from './loader'
+export {
+  CONFIG_DIR,
+  CONFIG_FILE,
+  fetchCloudId,
+  getConfig,
+  loadConfig,
+  normalizeApiPath,
+  normalizeProtocol,
+} from './loader'
 export { deleteProfile, initConfig, isValidProfileName, listProfiles, setActiveProfile } from './profiles'
 export type {
   AppConfig,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,6 +7,19 @@ import { CONFIG_DIR_NAME, CONFIG_FILE_NAME, DEFAULT_PROFILE, ENV_VARS } from './
 export const CONFIG_DIR = path.join(os.homedir(), CONFIG_DIR_NAME)
 export const CONFIG_FILE = path.join(CONFIG_DIR, CONFIG_FILE_NAME)
 
+export async function fetchCloudId(siteDomain: string): Promise<string> {
+  const url = `https://${siteDomain.replace(/\/$/, '')}/_edge/tenant_info`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch tenant info from ${url}: ${res.status} ${res.statusText}`)
+  }
+  const data = (await res.json()) as { cloudId?: string }
+  if (!data.cloudId) {
+    throw new Error(`No cloudId found in tenant info response from ${url}`)
+  }
+  return data.cloudId
+}
+
 export function normalizeApiPath(apiPath: string | undefined, domain: string): string {
   if (apiPath) return apiPath.startsWith('/') ? apiPath : `/${apiPath}`
   if (domain.includes('atlassian.net')) return '/wiki/rest/api'
@@ -25,8 +38,8 @@ export function normalizeProtocol(protocol: string | undefined): 'http' | 'https
 export function normalizeAuthType(authType: string | undefined, email: string | undefined): AuthType {
   if (authType) {
     const lower = authType.toLowerCase()
-    if (!['basic', 'bearer', 'mtls', 'cookie'].includes(lower)) {
-      throw new Error(`Invalid auth type "${authType}". Must be basic, bearer, mtls, or cookie.`)
+    if (!['basic', 'bearer', 'mtls', 'cookie', 'service-account'].includes(lower)) {
+      throw new Error(`Invalid auth type "${authType}". Must be basic, service-account, bearer, mtls, or cookie.`)
     }
     return lower as AuthType
   }
@@ -67,6 +80,9 @@ export function getEnvOverrides(): Partial<ResolvedConfig> & { profile?: string 
 
   const forceCloud = get(ENV_VARS.FORCE_CLOUD)
   if (forceCloud) overrides.forceCloud = forceCloud.toLowerCase() === 'true'
+
+  const siteUrl = get(ENV_VARS.SITE_URL)
+  if (siteUrl) overrides.siteUrl = siteUrl
 
   const linkStyle = get(ENV_VARS.LINK_STYLE)
   if (linkStyle) overrides.linkStyle = linkStyle
@@ -136,8 +152,22 @@ function validateConfig(raw: unknown): AppConfig {
   throw new Error('Invalid config format. Run "confluence init" to reinitialize.')
 }
 
-/** Normalize a profile from the flat JS format to nested auth format. */
 function normalizeProfileConfig(raw: Record<string, unknown>): ProfileConfig {
+  // Already in nested auth format — use directly
+  if (raw.auth && typeof raw.auth === 'object') {
+    return {
+      domain: String(raw.domain || ''),
+      protocol: (raw.protocol as 'http' | 'https') || undefined,
+      apiPath: (raw.apiPath as string) || undefined,
+      auth: raw.auth as AuthConfig,
+      readOnly: raw.readOnly as boolean | undefined,
+      forceCloud: raw.forceCloud as boolean | undefined,
+      siteUrl: (raw.siteUrl as string) || undefined,
+      linkStyle: raw.linkStyle as ProfileConfig['linkStyle'],
+    }
+  }
+
+  // Legacy flat format — migrate to nested auth
   const authType = normalizeAuthType(raw.authType as string | undefined, raw.email as string | undefined)
 
   let auth: AuthConfig
@@ -147,6 +177,9 @@ function normalizeProfileConfig(raw: Record<string, unknown>): ProfileConfig {
       break
     case 'bearer':
       auth = { type: 'bearer', token: String(raw.token || '') }
+      break
+    case 'service-account':
+      auth = { type: 'service-account', token: String(raw.token || '') }
       break
     case 'mtls':
       auth = {
@@ -168,6 +201,7 @@ function normalizeProfileConfig(raw: Record<string, unknown>): ProfileConfig {
     auth,
     readOnly: raw.readOnly as boolean | undefined,
     forceCloud: raw.forceCloud as boolean | undefined,
+    siteUrl: (raw.siteUrl as string) || undefined,
     linkStyle: raw.linkStyle as ProfileConfig['linkStyle'],
   }
 }
@@ -204,6 +238,7 @@ export function getConfig(profileName?: string): ResolvedConfig {
     tlsClientKey: envOverrides.tlsClientKey || ('tlsClientKey' in auth ? auth.tlsClientKey : undefined),
     readOnly: envOverrides.readOnly ?? profile.readOnly ?? false,
     forceCloud: envOverrides.forceCloud ?? profile.forceCloud ?? false,
+    siteUrl: envOverrides.siteUrl || profile.siteUrl,
     linkStyle: envOverrides.linkStyle || profile.linkStyle || 'auto',
   }
 }

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import { CONFIG_DIR, CONFIG_FILE, loadConfig, normalizeApiPath, normalizeAuthType, normalizeProtocol } from './loader'
+import { CONFIG_DIR, CONFIG_FILE, fetchCloudId, loadConfig, normalizeApiPath, normalizeAuthType, normalizeProtocol } from './loader'
 import type { AppConfig, ProfileConfig } from './types'
 import { DEFAULT_PROFILE } from './types'
 
@@ -83,7 +83,13 @@ export async function initConfig(cliOptions: {
         type: 'list',
         name: 'authType',
         message: 'Authentication type:',
-        choices: ['basic', 'bearer', 'mtls', 'cookie'],
+        choices: [
+          { name: 'basic - Email/username + API token', value: 'basic' },
+          { name: 'service-account - Atlassian service account (ATSTT token)', value: 'service-account' },
+          { name: 'bearer - Personal access token (Data Center)', value: 'bearer' },
+          { name: 'mtls - Client certificates', value: 'mtls' },
+          { name: 'cookie - Session cookie (Enterprise SSO)', value: 'cookie' },
+        ],
         default: cliOptions.authType || 'basic',
       },
       {
@@ -104,10 +110,42 @@ export async function initConfig(cliOptions: {
     ])
   }
 
-  const domain = (cliOptions.domain || answers.domain || '').trim()
-  const authType = normalizeAuthType(cliOptions.authType || answers.authType, cliOptions.email || answers.email)
+  const rawDomain = (cliOptions.domain || answers.domain || '').trim()
+  const rawAuthType = cliOptions.authType || answers.authType
+  const authType = normalizeAuthType(rawAuthType, cliOptions.email || answers.email)
+  const isServiceAccount = authType === 'service-account'
   const protocol = normalizeProtocol(cliOptions.protocol)
-  const apiPath = normalizeApiPath(cliOptions.apiPath, domain)
+
+  // For service accounts with atlassian.net domain, fetch cloudId and configure gateway
+  let domain = rawDomain
+  let apiPath = normalizeApiPath(cliOptions.apiPath, domain)
+  let siteUrl: string | undefined
+  let forceCloud: boolean | undefined
+
+  if (isServiceAccount && !cliOptions.apiPath) {
+    if (rawDomain.includes('atlassian.net')) {
+      console.log(chalk.blue('Fetching site info from tenant endpoint...'))
+      try {
+        const cloudId = await fetchCloudId(rawDomain)
+        siteUrl = `https://${rawDomain}`
+        domain = 'api.atlassian.com'
+        apiPath = `/ex/confluence/${cloudId}/wiki/rest/api`
+        forceCloud = true
+        console.log(chalk.green(`Cloud ID: ${cloudId}`))
+      } catch (err) {
+        throw new Error(
+          `Failed to fetch cloud ID for ${rawDomain}: ${(err as Error).message}\n` +
+            'You can provide the API path manually with --api-path "/ex/confluence/<cloudId>/wiki/rest/api"',
+        )
+      }
+    } else {
+      // Non-atlassian.net domain with service account — user must provide api-path manually
+      throw new Error(
+        'Service account auth requires an atlassian.net domain to auto-configure the API gateway.\n' +
+          'For custom domains, provide --api-path and --domain "api.atlassian.com" manually.',
+      )
+    }
+  }
 
   let profile: ProfileConfig
   switch (authType) {
@@ -130,6 +168,15 @@ export async function initConfig(cliOptions: {
         protocol,
         apiPath,
         auth: { type: 'bearer', token: (cliOptions.token || answers.token || '').trim() },
+        readOnly: cliOptions.readOnly ?? false,
+      }
+      break
+    case 'service-account':
+      profile = {
+        domain,
+        protocol,
+        apiPath,
+        auth: { type: 'service-account', token: (cliOptions.token || answers.token || '').trim() },
         readOnly: cliOptions.readOnly ?? false,
       }
       break
@@ -157,6 +204,9 @@ export async function initConfig(cliOptions: {
       }
       break
   }
+
+  if (siteUrl) profile.siteUrl = siteUrl
+  if (forceCloud) profile.forceCloud = forceCloud
 
   let config: AppConfig
   try {

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,7 +1,15 @@
 import fs from 'node:fs'
 import chalk from 'chalk'
 import inquirer from 'inquirer'
-import { CONFIG_DIR, CONFIG_FILE, fetchCloudId, loadConfig, normalizeApiPath, normalizeAuthType, normalizeProtocol } from './loader'
+import {
+  CONFIG_DIR,
+  CONFIG_FILE,
+  fetchCloudId,
+  loadConfig,
+  normalizeApiPath,
+  normalizeAuthType,
+  normalizeProtocol,
+} from './loader'
 import type { AppConfig, ProfileConfig } from './types'
 import { DEFAULT_PROFILE } from './types'
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,4 @@
-export type AuthType = 'basic' | 'bearer' | 'mtls' | 'cookie'
+export type AuthType = 'basic' | 'bearer' | 'mtls' | 'cookie' | 'service-account'
 
 export interface BasicAuthConfig {
   type: 'basic'
@@ -8,6 +8,11 @@ export interface BasicAuthConfig {
 
 export interface BearerAuthConfig {
   type: 'bearer'
+  token: string
+}
+
+export interface ServiceAccountAuthConfig {
+  type: 'service-account'
   token: string
 }
 
@@ -24,7 +29,12 @@ export interface CookieAuthConfig {
   cookie: string
 }
 
-export type AuthConfig = BasicAuthConfig | BearerAuthConfig | MtlsAuthConfig | CookieAuthConfig
+export type AuthConfig =
+  | BasicAuthConfig
+  | BearerAuthConfig
+  | ServiceAccountAuthConfig
+  | MtlsAuthConfig
+  | CookieAuthConfig
 
 export interface ProfileConfig {
   domain: string
@@ -33,6 +43,7 @@ export interface ProfileConfig {
   auth: AuthConfig
   readOnly?: boolean
   forceCloud?: boolean
+  siteUrl?: string
   linkStyle?: 'smart' | 'plain' | 'wiki' | 'auto'
 }
 
@@ -54,6 +65,7 @@ export interface ResolvedConfig {
   tlsClientKey?: string
   readOnly: boolean
   forceCloud: boolean
+  siteUrl?: string
   linkStyle: string
 }
 
@@ -69,6 +81,7 @@ export const ENV_VARS = {
   PROTOCOL: 'CONFLUENCE_PROTOCOL',
   READ_ONLY: 'CONFLUENCE_READ_ONLY',
   FORCE_CLOUD: 'CONFLUENCE_FORCE_CLOUD',
+  SITE_URL: 'CONFLUENCE_SITE_URL',
   LINK_STYLE: 'CONFLUENCE_LINK_STYLE',
   COOKIE: 'CONFLUENCE_COOKIE',
   TLS_CA_CERT: 'CONFLUENCE_TLS_CA_CERT',

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, afterEach } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { loadConfig, getEnvOverrides, normalizeApiPath, normalizeProtocol } from '../src/config/loader';
+import { fetchCloudId, loadConfig, getEnvOverrides, normalizeApiPath, normalizeAuthType, normalizeProtocol } from '../src/config/loader';
 import type { AppConfig } from '../src/config/types';
 
 const TMPDIR = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-cli-test-'));
@@ -12,7 +12,7 @@ afterEach(() => {
     'CONFLUENCE_DOMAIN', 'CONFLUENCE_HOST', 'CONFLUENCE_API_TOKEN', 'CONFLUENCE_PASSWORD',
     'CONFLUENCE_EMAIL', 'CONFLUENCE_USERNAME', 'CONFLUENCE_AUTH_TYPE', 'CONFLUENCE_API_PATH',
     'CONFLUENCE_PROTOCOL', 'CONFLUENCE_READ_ONLY', 'CONFLUENCE_FORCE_CLOUD',
-    'CONFLUENCE_LINK_STYLE', 'CONFLUENCE_COOKIE', 'CONFLUENCE_TLS_CA_CERT',
+    'CONFLUENCE_SITE_URL', 'CONFLUENCE_LINK_STYLE', 'CONFLUENCE_COOKIE', 'CONFLUENCE_TLS_CA_CERT',
     'CONFLUENCE_TLS_CLIENT_CERT', 'CONFLUENCE_TLS_CLIENT_KEY', 'CONFLUENCE_PROFILE',
   ];
   for (const v of envVars) delete process.env[v];
@@ -46,6 +46,47 @@ describe('normalizeProtocol', () => {
   });
 });
 
+describe('normalizeAuthType', () => {
+  it('preserves service-account as its own type', () => {
+    expect(normalizeAuthType('service-account', undefined)).toBe('service-account');
+  });
+
+  it('normalizes SERVICE-ACCOUNT case insensitively', () => {
+    expect(normalizeAuthType('SERVICE-ACCOUNT', undefined)).toBe('service-account');
+  });
+
+  it('preserves basic auth type', () => {
+    expect(normalizeAuthType('basic', 'user@example.com')).toBe('basic');
+  });
+
+  it('preserves bearer auth type', () => {
+    expect(normalizeAuthType('bearer', undefined)).toBe('bearer');
+  });
+
+  it('defaults to basic when email is provided', () => {
+    expect(normalizeAuthType(undefined, 'user@example.com')).toBe('basic');
+  });
+
+  it('defaults to bearer when no email', () => {
+    expect(normalizeAuthType(undefined, undefined)).toBe('bearer');
+  });
+
+  it('rejects invalid auth types', () => {
+    expect(() => normalizeAuthType('invalid', undefined)).toThrow(/Invalid auth type/);
+  });
+});
+
+describe('fetchCloudId', () => {
+  it('fetches cloudId from tenant_info endpoint', async () => {
+    const cloudId = await fetchCloudId('jos2p2.atlassian.net');
+    expect(cloudId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('throws for non-existent domain', async () => {
+    expect(fetchCloudId('nonexistent-invalid.atlassian.net')).rejects.toThrow();
+  });
+});
+
 describe('getEnvOverrides', () => {
   it('reads domain from CONFLUENCE_DOMAIN', () => {
     process.env.CONFLUENCE_DOMAIN = 'test.atlassian.net';
@@ -70,6 +111,12 @@ describe('getEnvOverrides', () => {
     process.env.CONFLUENCE_READ_ONLY = 'true';
     const overrides = getEnvOverrides();
     expect(overrides.readOnly).toBe(true);
+  });
+
+  it('reads site URL', () => {
+    process.env.CONFLUENCE_SITE_URL = 'https://example.atlassian.net';
+    const overrides = getEnvOverrides();
+    expect(overrides.siteUrl).toBe('https://example.atlassian.net');
   });
 
   it('returns empty object when no env vars set', () => {
@@ -146,6 +193,49 @@ describe('loadConfig', () => {
     expect(loaded.activeProfile).toBe('work');
     expect(loaded.profiles['work']!.auth.type).toBe('bearer');
     expect(loaded.profiles['personal']!.auth.type).toBe('basic');
+  });
+
+  it('preserves siteUrl in config', () => {
+    const config: AppConfig = {
+      activeProfile: 'default',
+      profiles: {
+        default: {
+          domain: 'api.atlassian.com',
+          apiPath: '/ex/confluence/abc-123/wiki/rest/api',
+          auth: { type: 'bearer', token: 'tok123' },
+          forceCloud: true,
+          siteUrl: 'https://example.atlassian.net',
+        },
+      },
+    };
+    const configPath = path.join(TMPDIR, 'siteurl.json');
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    const loaded = loadConfig(configPath);
+    expect(loaded.profiles['default']!.siteUrl).toBe('https://example.atlassian.net');
+  });
+
+  it('loads nested service-account auth without losing token', () => {
+    const config: AppConfig = {
+      activeProfile: 'default',
+      profiles: {
+        default: {
+          domain: 'api.atlassian.com',
+          apiPath: '/ex/confluence/cloud-uuid/wiki/rest/api',
+          auth: { type: 'service-account', token: 'ATSTT-secret-token' },
+          forceCloud: true,
+          siteUrl: 'https://example.atlassian.net',
+        },
+      },
+    };
+    const configPath = path.join(TMPDIR, 'sa-nested.json');
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    const loaded = loadConfig(configPath);
+    const profile = loaded.profiles['default']!;
+    expect(profile.auth.type).toBe('service-account');
+    expect(profile.auth.token).toBe('ATSTT-secret-token');
+    expect(profile.domain).toBe('api.atlassian.com');
+    expect(profile.forceCloud).toBe(true);
+    expect(profile.siteUrl).toBe('https://example.atlassian.net');
   });
 
   it('throws for active profile not in profiles', () => {


### PR DESCRIPTION
## Summary

- Add `service-account` as a first-class auth type for Atlassian service account tokens (ATSTT). When selected during `confluence init` with an `atlassian.net` domain, the CLI auto-fetches the cloud ID from `/_edge/tenant_info` and configures the `api.atlassian.com` gateway with the correct API path.
- Fix config loading bug where `normalizeProfileConfig` discarded nested `auth` objects from config.json, causing the token to be lost when the config used the nested format written by `initConfig`.
- Add `siteUrl` profile field to preserve the original site domain for correct page link generation when using the API gateway.
- Update CHANGELOG, README, and SKILL.md with service-account documentation.

## Test plan

- [x] 75 tests pass (11 new tests added covering `normalizeAuthType`, `fetchCloudId`, nested config loading)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Run `bun dev init`, select `service-account`, verify config.json has `auth.type: "service-account"` with token preserved
- [x] Run `confluence doctor` and verify credentials pass
- [x] Run `confluence space list` with a service account profile