### PR TITLE
fix: add service-account to profile add help text

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -42,7 +42,7 @@ export function registerProfileCommands(program: Command): void {
     .option('-d, --domain <domain>', 'Confluence domain')
     .option('--protocol <protocol>', 'Protocol (http or https)')
     .option('-p, --api-path <path>', 'REST API path')
-    .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, mtls, or cookie)')
+    .option('-a, --auth-type <type>', 'Authentication type (basic, service-account, bearer, mtls, or cookie)')
     .option('-e, --email <email>', 'Email or username for basic auth')
     .option('-t, --token <token>', 'API token')
     .option('-c, --cookie <cookie>', 'Cookie for Enterprise SSO authentication')


### PR DESCRIPTION
## Summary

Fixes #23

`confluence profile add --help` was missing `service-account` from the auth type description, listing only 4 options instead of 5.

## Changes

- `src/commands/profile.ts`: Added `service-account` to the `--auth-type` help text to match `confluence init`