### PR TITLE
fix: correct argument order in create-child command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed
+
+- `create-child` now passes `parentId` and `spaceKey` in the correct order to `createChildPage()`, which previously caused `Cannot extract page ID from "SD"` error (#20).
+
 ## [0.1.8] - 2026-04-27
 
 ### Added

--- a/src/commands/pages/crud.ts
+++ b/src/commands/pages/crud.ts
@@ -149,9 +149,9 @@ export async function handleCreateChild(
 
   const result = await pages.createChildPage(
     title,
-    spaceKey,
     parent,
     content,
+    spaceKey,
     (options.format ?? 'storage') as 'storage' | 'html' | 'markdown',
   )
 


### PR DESCRIPTION
## Summary

Fixes #20

`confluence create-child` was passing `spaceKey` and `parentId` in the wrong order to `pages.createChildPage()`, causing `Cannot extract page ID from "SD"`.

## Root Cause

`createChildPage()` signature: `(title, parentId, content, spaceKey, format)`
Call site was passing: `(title, spaceKey, parent, content, format)`

## Changes

- `src/commands/pages/crud.ts`: Swap arguments to match function signature
- `CHANGELOG.md`: Add entry under Unreleased