### PR TITLE
fix: decode HTML entities in attachment download URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. The format 
 
 For changes prior to this fork, see the [upstream changelog](https://github.com/pchuri/confluence-cli/blob/v1.33.0/CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed
+
+- Attachment download now decodes HTML entities (`&amp;` → `&`) in download URLs before making the request, which previously caused 404 errors (#15).
+
 ## [0.1.8] - 2026-04-27
 
 ### Added

--- a/src/client/attachments.ts
+++ b/src/client/attachments.ts
@@ -111,7 +111,7 @@ export class DefaultAttachmentsClient implements AttachmentsClient {
       downloadUrl = found.downloadLink
     }
 
-    const fullUrl = this.httpClient.buildUrl(downloadUrl)
+    const fullUrl = this.httpClient.buildUrl(downloadUrl.replace(/&amp;/g, '&'))
     const authHeaders = this.httpClient.buildAuthHeaders()
 
     const response = await axios.get(fullUrl, {


### PR DESCRIPTION
## Summary

Fixes #15

Confluence REST API returns download URLs with HTML-encoded ampersands (`&amp;`). The attachment download code passed this URL directly to `buildUrl()`, causing 404 errors because the server didn`t recognize the encoded query parameters.

## Changes

- `src/client/attachments.ts`: Decode `&amp;` to `&` in download URLs before building the full URL
- `CHANGELOG.md`: Add entry under Unreleased