### PR TITLE
test(pagination): add unit tests for shared pagination utilities

### DIFF
--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { parseNextStart, parsePaginationOptions } from '../../src/utils/pagination'
+
+describe('pagination utilities', () => {
+  describe('parseNextStart', () => {
+    test('returns undefined when next link is missing', () => {
+      expect(parseNextStart(undefined)).toBeUndefined()
+      expect(parseNextStart({})).toBeUndefined()
+    })
+
+    test('parses start from a relative next link query string', () => {
+      expect(parseNextStart({ next: '/rest/api/content/123/child/comment?limit=25&start=50' })).toBe(50)
+    })
+
+    test('parses start when it is the first query parameter', () => {
+      expect(parseNextStart({ next: '/rest/api/content/123/property?start=25&limit=25' })).toBe(25)
+    })
+
+    test('returns undefined when next link has no start parameter', () => {
+      expect(parseNextStart({ next: '/rest/api/content/123/property?limit=25' })).toBeUndefined()
+    })
+  })
+
+  describe('parsePaginationOptions', () => {
+    test('defaults to no limit and a zero start index', () => {
+      expect(parsePaginationOptions({})).toEqual({ limit: undefined, start: 0 })
+    })
+
+    test('parses positive limit and non-negative start strings', () => {
+      expect(parsePaginationOptions({ limit: '10', start: '20' })).toEqual({ limit: 10, start: 20 })
+    })
+
+    test('rejects invalid limits', () => {
+      expect(() => parsePaginationOptions({ limit: '0' })).toThrow('Limit must be a positive number.')
+      expect(() => parsePaginationOptions({ limit: '-1' })).toThrow('Limit must be a positive number.')
+      expect(() => parsePaginationOptions({ limit: 'not-a-number' })).toThrow('Limit must be a positive number.')
+    })
+
+    test('rejects invalid starts', () => {
+      expect(() => parsePaginationOptions({ start: '-1' })).toThrow('Start must be a non-negative number.')
+      expect(() => parsePaginationOptions({ start: 'not-a-number' })).toThrow('Start must be a non-negative number.')
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide unit coverage for the shared pagination utilities extracted in the refactor so their parsing and validation behavior is verified and protected against regressions.

### Description
- Add `tests/utils/pagination.test.ts` which exercises `parseNextStart` (missing/relative/first-param/no-start cases) and `parsePaginationOptions` (defaults, valid parsing, and invalid limit/start errors) against the existing `src/utils/pagination.ts` helpers.

### Testing
- Ran `bun test tests/utils/pagination.test.ts` which passed (8 tests, 0 failures).
- Attempted full `bun test` which ran a subset but failed in this environment (`fetchCloudId` returned 403 and some client tests errored due to missing `axios`), and `bun install` is blocked by registry `403` responses so full dependency restoration and lint/typecheck could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07fa7f73708321a3c66e3999925c35)